### PR TITLE
Update template to link stories to PT

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
+<!-- reporting stories from Pivotal Tracker (replace 'x' by the Story's id) -->
+This PR closes [#x](https://www.pivotaltracker.com/story/show/x), by:
+
+<!-- If you're linking a repository issue, use the following line instead:
 This PR closes #x, by:
+-->
 
 * Adding ...
 * Updating ...


### PR DESCRIPTION
This PR updates the PR template, by hardcoding the link to PT stories, so it's easier to access them when reviewing a PR.